### PR TITLE
Set lower bound on xlsx dependency

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.5
+resolver: nightly-2016-10-18
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/xlsx-tabular.cabal
+++ b/xlsx-tabular.cabal
@@ -26,7 +26,7 @@ library
                      , data-default
                      , lens
                      , text
-                     , xlsx
+                     , xlsx >= 0.3
   default-language:    Haskell2010
 
 test-suite xlsx-tabular-test


### PR DESCRIPTION
Without the lower bound a 0.2.x version may be selected and the build of xlsx-tabular will fail.
