### PR TITLE
Allow custom row predicates

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.5
+resolver: nightly-2016-10-18
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/xlsx-tabular.cabal
+++ b/xlsx-tabular.cabal
@@ -26,7 +26,7 @@ library
                      , data-default
                      , lens
                      , text
-                     , xlsx
+                     , xlsx >= 0.3
   default-language:    Haskell2010
 
 test-suite xlsx-tabular-test

--- a/xlsx-tabular.cabal
+++ b/xlsx-tabular.cabal
@@ -1,5 +1,5 @@
 name:                xlsx-tabular
-version:             0.1.0.2
+version:             0.1.1
 synopsis:            Xlsx table decode utility
 description:         Please see README.md
 homepage:            http://github.com/kkazuo/xlsx-tabular#readme


### PR DESCRIPTION
This will allow the non-“Japanese style” table formatting use cases mentioned in #1. The only change to the public API is the addition of the `toTableRowsCustom` which takes a custom row predicate which is used to decide when the table ends. The assumptions behind table formatting have been included in the documentation for the `Tabular` module. The version number was updated per the [Haskell Package Versioning Policy](http://pvp.haskell.org).
