### PR TITLE
Correct version bounds to avoid compile failure

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -33,3 +33,7 @@ extra-package-dbs: []
 
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
+
+# Enable Hackage-friendly mode, for more details see
+#  https://docs.haskellstack.org/en/stable/yaml_configuration/#pvp-bounds
+pvp-bounds: both

--- a/xlsx-tabular.cabal
+++ b/xlsx-tabular.cabal
@@ -19,7 +19,7 @@ library
                      , Codec.Xlsx.Util.Tabular.Types
                      , Codec.Xlsx.Util.Tabular.Imports
                      , Codec.Xlsx.Util.Tabular.Json
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.8 && < 5
                      , aeson
                      , bytestring
                      , containers


### PR DESCRIPTION
This avoids Cabal running into the compile failure below:

```
Configuring component lib from xlsx-tabular-0.2.1...
Preprocessing library xlsx-tabular-0.2.1...
[1 of 4] Compiling Codec.Xlsx.Util.Tabular.Types ( src/Codec/Xlsx/Util/Tabular/Types.hs, /tmp/matrix-worker/1484440518/dist-newstyle/build/x86_64-linux/ghc-7.8.4/xlsx-tabular-0.2.1/build/Codec/Xlsx/Util/Tabular/Types.o )
[2 of 4] Compiling Codec.Xlsx.Util.Tabular.Imports ( src/Codec/Xlsx/Util/Tabular/Imports.hs, /tmp/matrix-worker/1484440518/dist-newstyle/build/x86_64-linux/ghc-7.8.4/xlsx-tabular-0.2.1/build/Codec/Xlsx/Util/Tabular/Imports.o )
[3 of 4] Compiling Codec.Xlsx.Util.Tabular.Json ( src/Codec/Xlsx/Util/Tabular/Json.hs, /tmp/matrix-worker/1484440518/dist-newstyle/build/x86_64-linux/ghc-7.8.4/xlsx-tabular-0.2.1/build/Codec/Xlsx/Util/Tabular/Json.o )

src/Codec/Xlsx/Util/Tabular/Json.hs:19:21: Not in scope: ‘pure’
```