### PR TITLE
Use latest LTS rather than nightly snapshot.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration/
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: nightly-2017-01-14
+resolver: lts-8.13
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
Now that there is a compatible LTS (this was previously not the case) it is better to use it instead of a nightly snapshot which will not be available "long term".